### PR TITLE
Bug 370744 - make listDateRange() MYSQL 5.7 compliant

### DIFF
--- a/libs/database/item/imagelister.cpp
+++ b/libs/database/item/imagelister.cpp
@@ -398,7 +398,7 @@ void ImageLister::listDateRange(ImageListerReceiver* const receiver, const QDate
                                           " WHERE Images.status=1 "
                                           "   AND ImageInformation.creationDate < ? "
                                           "   AND ImageInformation.creationDate >= ? "
-                                          " ORDER BY Albums.id;"),
+                                          " ORDER BY Images.album;"),
                                   QDateTime(endDate).toString(Qt::ISODate),
                                   QDateTime(startDate).toString(Qt::ISODate),
                                   &values);


### PR DESCRIPTION
MYSQL 5.7 with default configuration introduced stricter query structure constraints.

This patch changes the ORDER BY clause to use Images.album instead of Albums.id, which causes an error since it is not in the SELECT DISTINCT clause.
As can be seen from the INNER JOIN clause Albums.id=Images.album this change does not alter the logic of the query.
